### PR TITLE
Fix genesis reward

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -375,41 +375,41 @@ BlockController.prototype.getBlockReward = function(prevHash, cb) {
         cb(null, parseFloat("50".toString(10)).toFixed(8));
     }
     else{
-    var dDiff = info.difficulty;
-    var nPrevHeight = info.height;
-
-    if (nPrevHeight < 5465) {
-      // Early ages...
-      // 1111/((x+1)^2)
-      nSubsidyBase = (1111.0 / (Math.pow((dDiff+1.0),2.0)));
-      if(nSubsidyBase > 500) nSubsidyBase = 500;
-      else if(nSubsidyBase < 1) nSubsidyBase = 1;
-    } else if (nPrevHeight < 17000 || (dDiff <= 75 && nPrevHeight < 24000)) {
-      // CPU mining era
-      // 11111/(((x+51)/6)^2)
-      nSubsidyBase = (11111.0 / (Math.pow((dDiff+51.0)/6.0,2.0)));
-      if(nSubsidyBase > 500) nSubsidyBase = 500;
-      else if(nSubsidyBase < 25) nSubsidyBase = 25;
-    } else {
-      // GPU/ASIC mining era
-      // 2222222/(((x+2600)/9)^2)
-      nSubsidyBase = (2222222.0 / (Math.pow((dDiff+2600.0)/9.0,2.0)));
-      if(nSubsidyBase > 25) nSubsidyBase = 25;
-      else if(nSubsidyBase < 5) nSubsidyBase = 5;
-    }
-
-    var nSubsidy = nSubsidyBase;
-
-    // yearly decline of production by ~7.1% per year, projected ~18M coins max by year 2050+.
-    for (var i = nSubsidyHalvingInterval; i <= nPrevHeight; i += nSubsidyHalvingInterval) {
-      nSubsidy -= nSubsidy/14;
-    }
-
-    // Hard fork to reduce the block reward by 10 extra percent (allowing budget/superblocks)
-    var nSuperblockPart = (nPrevHeight > nBudgetPaymentsStartBlock) ? nSubsidy/10 : 0;
-    var reward = nSubsidy - nSuperblockPart;
-
-    cb(null, parseFloat(reward.toString(10)).toFixed(8));
+	    var dDiff = info.difficulty;
+	    var nPrevHeight = info.height;
+	
+	    if (nPrevHeight < 5465) {
+	      // Early ages...
+	      // 1111/((x+1)^2)
+	      nSubsidyBase = (1111.0 / (Math.pow((dDiff+1.0),2.0)));
+	      if(nSubsidyBase > 500) nSubsidyBase = 500;
+	      else if(nSubsidyBase < 1) nSubsidyBase = 1;
+	    } else if (nPrevHeight < 17000 || (dDiff <= 75 && nPrevHeight < 24000)) {
+	      // CPU mining era
+	      // 11111/(((x+51)/6)^2)
+	      nSubsidyBase = (11111.0 / (Math.pow((dDiff+51.0)/6.0,2.0)));
+	      if(nSubsidyBase > 500) nSubsidyBase = 500;
+	      else if(nSubsidyBase < 25) nSubsidyBase = 25;
+	    } else {
+	      // GPU/ASIC mining era
+	      // 2222222/(((x+2600)/9)^2)
+	      nSubsidyBase = (2222222.0 / (Math.pow((dDiff+2600.0)/9.0,2.0)));
+	      if(nSubsidyBase > 25) nSubsidyBase = 25;
+	      else if(nSubsidyBase < 5) nSubsidyBase = 5;
+	    }
+	
+	    var nSubsidy = nSubsidyBase;
+	
+	    // yearly decline of production by ~7.1% per year, projected ~18M coins max by year 2050+.
+	    for (var i = nSubsidyHalvingInterval; i <= nPrevHeight; i += nSubsidyHalvingInterval) {
+	      nSubsidy -= nSubsidy/14;
+	    }
+	
+	    // Hard fork to reduce the block reward by 10 extra percent (allowing budget/superblocks)
+	    var nSuperblockPart = (nPrevHeight > nBudgetPaymentsStartBlock) ? nSubsidy/10 : 0;
+	    var reward = nSubsidy - nSuperblockPart;
+	
+	    cb(null, parseFloat(reward.toString(10)).toFixed(8));
     }
   });
 };

--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -341,20 +341,23 @@ BlockController.prototype.formatTimestamp = function(date) {
  */
 BlockController.prototype.getPreviousBlock = function(prevHash, cb) {
   var self = this;
-
-  self.node.getBlock(prevHash, function(err, block) {
-    if((err && err.code === -5) || (err && err.code === -8)) {
-      return self.common.handleErrors(null, res);
-    } else if(err) {
-      return self.common.handleErrors(err, res);
-    }
-    self.node.services.bitcoind.getBlockHeader(prevHash, function(err, info) {
-      if (err) {
-        return self.common.handleErrors(err, info);
-      }
-      cb(null, info); // return blockHeader
-    });
-  });
+  //On genesis block, the previousHash will be null.
+  if(prevHash===null) cb(null,null);
+  else {
+      self.node.getBlock(prevHash, function (err, block) {
+          if ((err && err.code === -5) || (err && err.code === -8)) {
+              return self.common.handleErrors(null, res);
+          } else if (err) {
+              return self.common.handleErrors(err, res);
+          }
+          self.node.services.bitcoind.getBlockHeader(prevHash, function (err, info) {
+              if (err) {
+                  return self.common.handleErrors(err, info);
+              }
+              cb(null, info); // return blockHeader
+          });
+      });
+  }
 };
 
 BlockController.prototype.getBlockReward = function(prevHash, cb) {

--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -369,7 +369,12 @@ BlockController.prototype.getBlockReward = function(prevHash, cb) {
   // block reward is based on the previous block diff / height
   self.getPreviousBlock(prevHash, function(err, info) {
     if(err) cb(err, null);
-
+    //if we seek for prevHash of genesis, previousBlock return an info being null.
+    if(info===null){
+        //Genesis reward is 50.
+        cb(null, parseFloat("50".toString(10)).toFixed(8));
+    }
+    else{
     var dDiff = info.difficulty;
     var nPrevHeight = info.height;
 
@@ -405,6 +410,7 @@ BlockController.prototype.getBlockReward = function(prevHash, cb) {
     var reward = nSubsidy - nSuperblockPart;
 
     cb(null, parseFloat(reward.toString(10)).toFixed(8));
+    }
   });
 };
 


### PR DESCRIPTION
When we ask for genesis block using /block/0 or /block/00000ffd590b1485b3caadc19b22e6379c733355108f107a430458cdf3407ab6 (on livenet). 
We try to retrieve the reward of that block. 
Because the reward is a function of difficulty and height, we will fetch the previousBlock of genesis, which is null. 
In these case, the insight-api will end up crashing. 

This fix that case returning 50 as genesis block reward. 