### PR TITLE
Fix: Add rawtx existance verif and handle error if not.

### DIFF
--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -303,7 +303,13 @@ TxController.prototype.list = function(req, res) {
 
 TxController.prototype.send = function(req, res) {
   var self = this;
-  this.node.sendTransaction(req.body.rawtx, function(err, txid) {
+	if(_.isUndefined(req.body.rawtx)){
+		return self.common.handleErrors({
+			message:"Missing parameter (expected 'rawtx' a string)",
+			code:1
+		}, res);
+	}
+	this.node.sendTransaction(req.body.rawtx, function(err, txid) {
     if(err) {
       // TODO handle specific errors
       return self.common.handleErrors(err, res);


### PR DESCRIPTION
If we try to broadcast a transaction without giving out a rawtx parameters.
The errors won't be catch until a TypeError is thrown by bitcoind-rpc-dash.
The client do not have any way to understand the issue aswell.
In order to fix that, we check the existance of rawtx and handle the case where it doesn't exist, gracefully sending the information to clients.