### PR TITLE
Add instant send support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -193,6 +193,7 @@ InsightAPI.prototype.setupRoutes = function(app) {
   app.param('txid', transactions.transaction.bind(transactions));
   app.get('/txs', this.cacheShort(), transactions.list.bind(transactions));
   app.post('/tx/send', transactions.send.bind(transactions));
+  app.post('/tx/sendix', transactions.sendix.bind(transactions));
 
   // Raw Routes
   app.get('/rawtx/:txid', this.cacheLong(), transactions.showRaw.bind(transactions));

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -312,5 +312,22 @@ TxController.prototype.send = function(req, res) {
     res.json({'txid': txid});
   });
 };
-
+//Handler for InstantSend 
+TxController.prototype.sendix = function(req, res) {
+	var self = this;
+	if(_.isUndefined(req.body.rawtx)){
+		return self.common.handleErrors({
+			message:"Missing parameter (expected 'rawtx' a string)",
+			code:1
+		}, res);
+	}
+	var options = {allowAbsurdFees: false, isInstasend: true};
+	this.node.sendTransaction(req.body.rawtx, options, function(err, txid) {
+		if(err) {
+			// TODO handle specific errors
+			return self.common.handleErrors(err, res);
+		}
+		res.json({'txid': txid});
+	});
+};
 module.exports = TxController;

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -321,7 +321,7 @@ TxController.prototype.sendix = function(req, res) {
 			code:1
 		}, res);
 	}
-	var options = {allowAbsurdFees: false, isInstasend: true};
+	var options = {allowAbsurdFees: false, isInstantSend: true};
 	this.node.sendTransaction(req.body.rawtx, options, function(err, txid) {
 		if(err) {
 			// TODO handle specific errors

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "bitcoreNode": "lib",
   "dependencies": {
     "async": "*",
-    "bitcore-lib-dash": "^0.14.0",
+    "bitcore-lib-dash": "^0.13.20",
     "bitcore-message-dash": "^1.0.5",
     "body-parser": "^1.13.3",
     "compression": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "bitcoreNode": "lib",
   "dependencies": {
     "async": "*",
-    "bitcore-lib-dash": "^0.13.20",
+    "bitcore-lib-dash": "^0.14.0",
     "bitcore-message-dash": "^1.0.5",
     "body-parser": "^1.13.3",
     "compression": "^1.6.1",


### PR DESCRIPTION
This P.R create a new route `/tx/sendix` which takes the same parameters than `/tx/send`, but will perform an instantSend transaction.