### PR TITLE
Feat : Added GET route masternodes/list

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ var AddressController = require('./addresses');
 var GovObjectController = require('./govobject');
 var StatusController = require('./status');
 var MessagesController = require('./messages');
+var MasternodesController = require('./masternodes');
 var UtilsController = require('./utils');
 var CurrencyController = require('./currency');
 var RateLimiter = require('./ratelimiter');
@@ -216,7 +217,11 @@ InsightAPI.prototype.setupRoutes = function(app) {
   var govObject = new GovObjectController(this.node);
   app.get('/gobject/list/:filter', this.cacheShort(), govObject.list.bind(govObject));
   app.get('/gobject/get/:hash', this.cacheShort(), govObject.checkHash.bind(govObject), govObject.show.bind(govObject));
-
+  
+  //Masternodes
+  var masternodes = new MasternodesController(this.node);  
+  app.get('/masternodes/list', this.cacheShort(), masternodes.list.bind(masternodes));
+  
   // Status route
   var status = new StatusController(this.node);
   app.get('/status', this.cacheShort(), status.show.bind(status));

--- a/lib/masternodes.js
+++ b/lib/masternodes.js
@@ -17,10 +17,9 @@ MasternodeController.prototype.list = function(req, res) {
 	});
 };
 MasternodeController.prototype.getMNList = function(callback) {
-	var self = this;
 	this.node.services.bitcoind.getMNList(function(err, result) {
 		if (err) {
-			return self.common.handleErrors(err, res);
+			return callback(err);
 		}
 		var MNlist = [];
 		var keys = Object.keys(result);
@@ -39,7 +38,7 @@ MasternodeController.prototype.getMNList = function(callback) {
 			    ip:  MNdetails[7]
 		    });
 		}
-		callback(MNlist);
+		callback(null,MNlist);
 	});
 };
 module.exports = MasternodeController;

--- a/lib/masternodes.js
+++ b/lib/masternodes.js
@@ -17,28 +17,12 @@ MasternodeController.prototype.list = function(req, res) {
 	});
 };
 MasternodeController.prototype.getMNList = function(callback) {
-	this.node.services.bitcoind.getMNList(function(err, result) {
+	this.node.services.bitcoind.getMNList(function(err, result){
+		var MNList = result || [];
 		if (err) {
 			return callback(err);
 		}
-		var MNlist = [];
-		var keys = Object.keys(result);
-		for (var i=0;i<keys.length; i++) {
-			var key = keys[i];
-	        var MNdetails = result[key].split(/[ ]+/); //split by whitespace
-			MNlist.push({
-			    vin: key,
-			    status: MNdetails[0],
-			    protocol: MNdetails[1],
-			    payee: MNdetails[2],
-			    lastseen: MNdetails[3],
-			    activeseconds: MNdetails[4],
-			    lastpaidtime: MNdetails[5],
-			    lastpaidblock: MNdetails[6],
-			    ip:  MNdetails[7]
-		    });
-		}
-		callback(null,MNlist);
+		callback(null,MNList);
 	});
 };
 module.exports = MasternodeController;

--- a/lib/masternodes.js
+++ b/lib/masternodes.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var Common = require('./common');
+
+function MasternodeController(node) {
+	this.node = node;
+	this.common = new Common({log: this.node.log});
+}
+
+MasternodeController.prototype.list = function(req, res) {
+	var self = this;
+	this.getMNList(function(err, result) {
+		if (err) {
+			return self.common.handleErrors(err, res);
+		}
+		res.jsonp(result);
+	});
+};
+MasternodeController.prototype.getMNList = function(callback) {
+	var self = this;
+	this.node.services.bitcoind.getMNList(function(err, result) {
+		if (err) {
+			return self.common.handleErrors(err, res);
+		}
+		var MNlist = [];
+		var keys = Object.keys(result);
+		for (var i=0;i<keys.length; i++) {
+			var key = keys[i];
+	        var MNdetails = result[key].split(/[ ]+/); //split by whitespace
+			MNlist.push({
+			    vin: key,
+			    status: MNdetails[0],
+			    protocol: MNdetails[1],
+			    payee: MNdetails[2],
+			    lastseen: MNdetails[3],
+			    activeseconds: MNdetails[4],
+			    lastpaidtime: MNdetails[5],
+			    lastpaidblock: MNdetails[6],
+			    ip:  MNdetails[7]
+		    });
+		}
+		callback(MNlist);
+	});
+};
+module.exports = MasternodeController;

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "bitcoreNode": "lib",
   "dependencies": {
     "async": "*",
-    "bitcore-lib-dash": "^0.13.20",
+    "bitcore-lib-dash": "^0.14.0",
     "bitcore-message-dash": "^1.0.5",
     "body-parser": "^1.13.3",
     "compression": "^1.6.1",

--- a/test/masternodes.js
+++ b/test/masternodes.js
@@ -1,0 +1,85 @@
+'use strict';
+
+var sinon = require('sinon');
+var should = require('should');
+var MasternodesController = require('../lib/masternodes');
+
+describe('Masternode', function() {
+	describe('/masternodes/list', function () {
+		var MNList = [{
+			"vin": "f31bd0fcb34317a3db0dbf607c899d022c9e8a9d712c94c87bac953caafcf1a2-1",
+			"status": "ENABLED",
+			"rank": 1,
+			"ip": "52.202.12.210:9999",
+			"protocol": 70206,
+			"payee": "Xjd6yGfWcsuDcHdECCwn3XUScLb3q3ChJK",
+			"activeseconds": 14556663,
+			"lastseen": 1502078628
+		}, {
+			"vin": "c097539c6d03e45d8933b92d7cd702c6906b74f16860ddaedb33107e940fea27-0",
+			"status": "ENABLED",
+			"rank": 2,
+			"ip": "37.59.247.180:9999",
+			"protocol": 70206,
+			"payee": "Xk8LPywDnggrAQaVWTkLk1JMabs1ZRLWT5",
+			"activeseconds": 312936,
+			"lastseen": 1502078652
+		}, {
+			"vin": "f1de44e05cfc54ef70b6f2769f3ef9289c858ea7f0356012836ec9d0581f5ea3-1",
+			"status": "ENABLED",
+			"rank": 3,
+			"ip": "45.76.178.221:9999",
+			"protocol": 70206,
+			"payee": "XpwGvnRwjbMmT1hyA6nS5NesdJk4d4bE3y",
+			"activeseconds": 3714536,
+			"lastseen": 1502078813
+		}, {
+			"vin": "2326359e1e0fed73063f0330d0d5d32d70ddfb427e7135fc3d678be49ac9022b-1",
+			"status": "ENABLED",
+			"rank": 4,
+			"ip": "46.101.153.25:9999",
+			"protocol": 70206,
+			"payee": "XyxESWr2mPz5JQmrX5w1TQBRLMgM5MoE1K",
+			"activeseconds": 12092763,
+			"lastseen": 1502078485
+		}, {
+			"vin": "1297deb0f9cbd1443114ac15cb2fe42a69a182de9ebdf2b109114f61d2283798-1",
+			"status": "ENABLED",
+			"rank": 5,
+			"ip": "178.62.218.126:9999",
+			"protocol": 70206,
+			"payee": "Xog5c8MG6Qneu1hZfLuUwjWqaWjD6Fbrdk",
+			"activeseconds": 11796620,
+			"lastseen": 1502078972
+		}];
+		var node = {
+			services: {
+				bitcoind: {
+					getMNList: sinon.stub().callsArgWith(0, null, MNList)
+				}
+			}
+		};
+
+		var masternodes = new MasternodesController(node);
+
+		it('getList', function (done) {
+			var req = {};
+			var res = {
+				jsonp: function (data) {
+					data.length.should.equal(5);
+					should.exist(data[0].vin);
+					should.exist(data[0].status);
+					should.exist(data[0].rank);
+					should.exist(data[0].ip);
+					should.exist(data[0].protocol);
+					should.exist(data[0].payee);
+					should.exist(data[0].activeseconds);
+					should.exist(data[0].lastseen);
+					done();
+				}
+			};
+
+			masternodes.list(req, res);
+		});
+	});
+});


### PR DESCRIPTION
This P.R add a new routes : [GET] `/masternode/list`. 

Multiple things to notice : 
- It require bitcore-node-dash to implement getMNList in bitcore-node-dash/lib/services/bitcoind.js (P/R waiting in dashevo/bitcore-node-dash)
- Which itself require the last version of bitcoind-rpc-dash with masternodelist rpc command in it (already available).
- The retrieval is slow in this current state (~20 seconds).

As of current state : **Not ready to be merged**.