### PR TITLE
Feature/insight version

### DIFF
--- a/lib/status.js
+++ b/lib/status.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Common = require('./common');
+var insightVersion = require('../package.json').version || null;
 
 function StatusController(node) {
   this.node = node;
@@ -51,6 +52,7 @@ StatusController.prototype.getInfo = function(callback) {
     }
     var info = {
       version: result.version,
+      insightversion: insightVersion,
       protocolversion: result.protocolVersion,
       blocks: result.blocks,
       timeoffset: result.timeOffset,

--- a/test/status.js
+++ b/test/status.js
@@ -8,6 +8,7 @@ describe('Status', function() {
   describe('/status', function() {
     var info = {
       version: 110000,
+      insightVersion:"0.5.0", 
       protocolVersion: 70002,
       blocks: 548645,
       timeOffset: 0,
@@ -47,6 +48,7 @@ describe('Status', function() {
       var res = {
         jsonp: function(data) {
           should.exist(data.info.version);
+          should.exist(data.info.insightversion);
           should.exist(data.info.protocolversion);
           should.exist(data.info.blocks);
           should.exist(data.info.timeoffset);


### PR DESCRIPTION
This aims to add "insightVersion" to the route `/status`. 
In a evo context, this will allow to filter the insight version running on a MN and allow a better selection accross masternodes.
DAPI need this value in order to prepare a MNList (see EV-204)