### PR TITLE
Feature/get headers

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -73,7 +73,7 @@ BlockController.prototype.blockHeader = function(req, res, next) {
 BlockController.prototype.blockHeaders = function(req, res, next) {
 	var self = this;
 	var blockIdentifier = req.params.blockIdentifier;
-	var nbOfBlockToFetch = req.params.nbOfBlock || 25;
+	var nbOfBlockToFetch = ((req.params.hasOwnProperty('nbOfBlock')) ? (parseInt(req.params.nbOfBlock)>0 && parseInt(req.params.nbOfBlock) || false) : false) || 25;
 	var cb = function(err, headers) {
 		if (err) {
 			return self.common.handleErrors(err, res);

--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -51,6 +51,49 @@ BlockController.prototype.checkBlockHash = function(req, res, next) {
 };
 
 /**
+ * Find block header by hash ...
+ */
+BlockController.prototype.blockHeader = function(req, res, next) {
+	var self = this;
+	var hash = req.params.blockHash;
+
+	self.node.services.bitcoind.getBlockHeader(hash, function(err, info) {
+		if (err) {
+			return self.common.handleErrors(err, res);
+		}
+		req.blockHeader = info;
+		next();
+	});
+};
+
+/**
+ * Retrieve an array of blockHeaders from a starting hash point
+ * By default (i.e no nbOfBlock specified) it will return only 25 blocks
+ */
+BlockController.prototype.blockHeaders = function(req, res, next) {
+	var self = this;
+	var blockIdentifier = req.params.blockIdentifier;
+	var nbOfBlockToFetch = req.params.nbOfBlock || 25;
+	var cb = function(err, headers) {
+		if (err) {
+			return self.common.handleErrors(err, res);
+		}
+		else{
+			res.jsonp({headers:headers});
+		}
+	};
+
+	if(blockIdentifier.length===64){
+		var hash = blockIdentifier;
+		var result = self.node.services.bitcoind.getBlockHeaders(hash, cb, nbOfBlockToFetch);
+	}else{
+		var height = blockIdentifier;
+		var result = self.node.services.bitcoind.getBlockHeaders(height, cb, nbOfBlockToFetch);
+	}
+
+};
+
+/**
  * Find block by hash ...
  */
 BlockController.prototype.block = function(req, res, next) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -188,6 +188,11 @@ InsightAPI.prototype.setupRoutes = function(app) {
 
   app.get('/block-index/:height', this.cacheShort(), blocks.blockIndex.bind(blocks));
   app.param('height', blocks.blockIndex.bind(blocks));
+  
+  //Return 25 next blocks from blockHash or blockHeigth
+  app.get('/block-headers/:blockIdentifier',this.cacheLong(),blocks.blockHeaders.bind(blocks));
+  //Return nbOfBlock's blocks next from blockHash or blockHeight
+  app.get('/block-headers/:blockIdentifier/:nbOfBlock',this.cacheLong(),blocks.blockHeaders.bind(blocks));
 
   // Transaction routes
   var transactions = new TxController(this.node);

--- a/test/blocks.js
+++ b/test/blocks.js
@@ -363,3 +363,71 @@ describe('Blocks', function() {
     blocks.getBlockReward('000000000000c53bf17a98b9ee042d6d4c3faf37d7a9f5c1335cce6df896f2f4', cb); // should return difficulty of block 100000
   });
 });
+
+describe('#getHeaders', function(){
+	describe('/block-headers/:height route', function() {
+		var node = {
+			log: sinon.stub(),
+			services: {
+				bitcoind: {
+					getBlockHeaders: function(height, callback) {
+						callback(null, blockIndexes[height]);
+					}
+				}
+			}
+		};
+		it('should give an array of 25 block headers', function() {
+			var blocks = new BlockController({node: node});
+			var insight = {
+				'blockHash': '0000000000000afa0c3c0afd450c793a1e300ec84cbe9555166e06132f19a8f7'
+			};
+			var height = 533974;
+			var req = {
+				params: {
+					blockHash: "0000000000000afa0c3c0afd450c793a1e300ec84cbe9555166e06132f19a8f7"
+				}
+			};
+			var res = {
+				jsonp: function(data) {
+					should(data).eql(insight);
+					done();
+				}
+			};
+
+			blocks.blockHeaders(req, res);
+		});
+	});
+	describe('/block-headers/:height/:nbOfBlock route', function() {
+		var node = {
+			log: sinon.stub(),
+			services: {
+				bitcoind: {
+					getBlockHeaders: function(height, callback) {
+						callback(null, blockIndexes[height]);
+					}
+				}
+			}
+		};
+		it('should give an array of 50 block headers', function() {
+			var blocks = new BlockController({node: node});
+			var insight = {
+				'blockHash': '0000000000000afa0c3c0afd450c793a1e300ec84cbe9555166e06132f19a8f7'
+			};
+			var height = 533974;
+			var req = {
+				params: {
+					blockHash: "0000000000000afa0c3c0afd450c793a1e300ec84cbe9555166e06132f19a8f7",
+					nbOfBlocks:50
+				}
+			};
+			var res = {
+				jsonp: function(data) {
+					should(data).eql(insight);
+					done();
+				}
+			};
+
+			blocks.blockHeaders(req, res);
+		});
+	});
+});

--- a/test/blocks.js
+++ b/test/blocks.js
@@ -56,6 +56,24 @@ var blockIndexes = {
     height: 599999,
     difficulty: 75786.58855499285
   },
+  '0000047d24635e347be3aaaeb66c26be94901a2f962feccd4f95090191f208c1':{
+    hash: '0000047d24635e347be3aaaeb66c26be94901a2f962feccd4f95090191f208c1',
+    chainWork: '0000000000000000000000000000000000000000000000000000000000200011',
+    prevHash: '00000bafbc94add76cb75e2ec92894837288a481e5c005f6563d91623bf8bc2c',
+    nextHash: '00000c6264fab4ba2d23990396f42a76aa4822f03cbc7634b79f4dfea36fccc2',
+    confirmations: 40493,
+    height: 1,
+    difficulty: 0.0002441371325370145
+  },
+  1:{
+    hash: '0000047d24635e347be3aaaeb66c26be94901a2f962feccd4f95090191f208c1',
+    chainWork: '0000000000000000000000000000000000000000000000000000000000200011',
+    prevHash: '00000bafbc94add76cb75e2ec92894837288a481e5c005f6563d91623bf8bc2c',
+    nextHash: '00000c6264fab4ba2d23990396f42a76aa4822f03cbc7634b79f4dfea36fccc2',
+    confirmations: 40493,
+    height: 1,
+    difficulty: 0.0002441371325370145
+  },
   533974: {
     hash: '0000000000000afa0c3c0afd450c793a1e300ec84cbe9555166e06132f19a8f7',
     chainWork: '0000000000000000000000000000000000000000000000054626b1839ade284a',
@@ -370,31 +388,42 @@ describe('#getHeaders', function(){
 			log: sinon.stub(),
 			services: {
 				bitcoind: {
-					getBlockHeaders: function(height, callback) {
-						callback(null, blockIndexes[height]);
+					getBlockHeaders: function(blockIdentifier, callback, nbBlock) {
+					  var result = [];
+					  for(var i = 0; i<nbBlock; i++){
+					    result.push(blockIndexes[blockIdentifier])
+            }
+						callback(null, result);
 					}
 				}
 			}
 		};
 		it('should give an array of 25 block headers', function() {
 			var blocks = new BlockController({node: node});
+
 			var insight = {
-				'blockHash': '0000000000000afa0c3c0afd450c793a1e300ec84cbe9555166e06132f19a8f7'
-			};
-			var height = 533974;
+        hash: '0000047d24635e347be3aaaeb66c26be94901a2f962feccd4f95090191f208c1',
+        chainWork: '0000000000000000000000000000000000000000000000000000000000200011',
+        prevHash: '00000bafbc94add76cb75e2ec92894837288a481e5c005f6563d91623bf8bc2c',
+        nextHash: '00000c6264fab4ba2d23990396f42a76aa4822f03cbc7634b79f4dfea36fccc2',
+        confirmations: 40493,
+        height: 1,
+        difficulty: 0.0002441371325370145
+    };
 			var req = {
 				params: {
-					blockHash: "0000000000000afa0c3c0afd450c793a1e300ec84cbe9555166e06132f19a8f7"
+          blockIdentifier: "0000047d24635e347be3aaaeb66c26be94901a2f962feccd4f95090191f208c1"
 				}
 			};
 			var res = {
 				jsonp: function(data) {
-					should(data).eql(insight);
-					done();
+				  data.should.have.property('headers');
+          data.headers.should.have.length(25);
+					should(data.headers[0]).eql(insight);
 				}
 			};
 
-			blocks.blockHeaders(req, res);
+      blocks.blockHeaders(req, res)
 		});
 	});
 	describe('/block-headers/:height/:nbOfBlock route', function() {
@@ -402,28 +431,39 @@ describe('#getHeaders', function(){
 			log: sinon.stub(),
 			services: {
 				bitcoind: {
-					getBlockHeaders: function(height, callback) {
-						callback(null, blockIndexes[height]);
-					}
+          getBlockHeaders: function(blockIdentifier, callback, nbBlock) {
+            var result = [];
+            for(var i = 0; i<nbBlock; i++){
+              result.push(blockIndexes[blockIdentifier])
+            }
+            callback(null, result);
+          }
 				}
 			}
 		};
 		it('should give an array of 50 block headers', function() {
 			var blocks = new BlockController({node: node});
 			var insight = {
-				'blockHash': '0000000000000afa0c3c0afd450c793a1e300ec84cbe9555166e06132f19a8f7'
+        hash: '0000047d24635e347be3aaaeb66c26be94901a2f962feccd4f95090191f208c1',
+        chainWork: '0000000000000000000000000000000000000000000000000000000000200011',
+        prevHash: '00000bafbc94add76cb75e2ec92894837288a481e5c005f6563d91623bf8bc2c',
+        nextHash: '00000c6264fab4ba2d23990396f42a76aa4822f03cbc7634b79f4dfea36fccc2',
+        confirmations: 40493,
+        height: 1,
+        difficulty: 0.0002441371325370145
 			};
 			var height = 533974;
 			var req = {
 				params: {
-					blockHash: "0000000000000afa0c3c0afd450c793a1e300ec84cbe9555166e06132f19a8f7",
-					nbOfBlocks:50
+					blockIdentifier: "0000047d24635e347be3aaaeb66c26be94901a2f962feccd4f95090191f208c1",
+					nbOfBlock:50
 				}
 			};
 			var res = {
 				jsonp: function(data) {
-					should(data).eql(insight);
-					done();
+          data.should.have.property('headers');
+          data.headers.should.have.length(50);
+          should(data.headers[0]).eql(insight);
 				}
 			};
 


### PR DESCRIPTION
Dependent : https://github.com/dashevo/bitcore-node-dash/pull/5

This P.R aims to allow to retrieve multiple block (getHeaders) providing different possibility :

* We can ask to start from from a block hash or a block height as a starting point.
* We can ask for 25 block (default) or by specifying a specific number of block. 

Later improvement possible : 
* If we agree that we limit to 250 block, we will want to setup that also at this place. (Edit : done in bitcore-node)
* Ability to revert search ? (asking -25 from height 200 will give 150 to 200 ?)