### PR TITLE
Fix : Handle TypeError on undefined res object.

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -9,15 +9,19 @@ Common.prototype.notReady = function (err, res, p) {
 };
 
 Common.prototype.handleErrors = function (err, res) {
-  if (err) {
-    if (err.code)  {
-      res.status(400).send(err.message + '. Code:' + err.code);
-    } else {
-      this.log.error(err.stack);
-      res.status(503).send(err.message);
-    }
+  if(!res || !res.hasOwnProperty('status')) {
+     	console.error("Missing res object, err:",err);
   } else {
-    res.status(404).send('Not found');
+    if (err) {
+      if (err.code)  {
+        res.status(400).send(err.message + '. Code:' + err.code);
+      } else {
+        this.log.error(err.stack);
+        res.status(503).send(err.message);
+      }
+    } else {
+      res.status(404).send('Not found');
+    }
   }
 };
 


### PR DESCRIPTION
On some case, if Insight has already returned a RPCError, it won't be able to access the res object.