### PR TITLE
V 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,26 @@ Sample output:
 ```
   /insight-api-dash/masternodes/list
 ```
+### Validate Masternode
+```
+  /insight-api-dash/masternodes/validate/[:payee]
+  /insight-api-dash/masternodes/validate/yRuALkPpeYpTgxdNn2L5YgGktASJYDYPAo
+```
+
+Sample valid output:
+```
+    {
+        "valid":true,
+        "vin":"e3a6b7878a7e9413898bb379b323c521676f9d460db17ec3bf42d9ac0c9a432f-1",
+        "status":"ENABLED",
+        "rank":1,
+        "ip":"217.182.229.146:19999",
+        "protocol":70208,
+        "payee":"yRuALkPpeYpTgxdNn2L5YgGktASJYDYPAo",
+        "activeseconds":158149,
+        "lastseen":1507810068
+    }
+```
 
 ### Historic Blockchain Data Sync Status
 ```
@@ -658,4 +678,4 @@ Caching support has not yet been added in the v0.3 upgrade.
 
 ## Resources
 
-- (Medium)[How to setup a Dash Instant-Send Transaction using Insight API — The comprehensive way](https://medium.com/@obusco/setup-instant-send-transaction-the-comprehensive-way-a80a8a0572e)
+- (Medium)[How to setup a Dash Instant-Send Transaction using Insight API?????????The comprehensive way](https://medium.com/@obusco/setup-instant-send-transaction-the-comprehensive-way-a80a8a0572e)

--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -51,6 +51,49 @@ BlockController.prototype.checkBlockHash = function(req, res, next) {
 };
 
 /**
+ * Find block header by hash ...
+ */
+BlockController.prototype.blockHeader = function(req, res, next) {
+	var self = this;
+	var hash = req.params.blockHash;
+
+	self.node.services.bitcoind.getBlockHeader(hash, function(err, info) {
+		if (err) {
+			return self.common.handleErrors(err, res);
+		}
+		req.blockHeader = info;
+		next();
+	});
+};
+
+/**
+ * Retrieve an array of blockHeaders from a starting hash point
+ * By default (i.e no nbOfBlock specified) it will return only 25 blocks
+ */
+BlockController.prototype.blockHeaders = function(req, res, next) {
+	var self = this;
+	var blockIdentifier = req.params.blockIdentifier;
+	var nbOfBlockToFetch = ((req.params.hasOwnProperty('nbOfBlock')) ? (parseInt(req.params.nbOfBlock)>0 && parseInt(req.params.nbOfBlock) || false) : false) || 25;
+	var cb = function(err, headers) {
+		if (err) {
+			return self.common.handleErrors(err, res);
+		}
+		else{
+			res.jsonp({headers:headers});
+		}
+	};
+
+	if(blockIdentifier.length===64){
+		var hash = blockIdentifier;
+		var result = self.node.services.bitcoind.getBlockHeaders(hash, cb, nbOfBlockToFetch);
+	}else{
+		var height = blockIdentifier;
+		var result = self.node.services.bitcoind.getBlockHeaders(height, cb, nbOfBlockToFetch);
+	}
+
+};
+
+/**
  * Find block by hash ...
  */
 BlockController.prototype.block = function(req, res, next) {

--- a/lib/govobject.js
+++ b/lib/govobject.js
@@ -61,8 +61,6 @@ GovObjectController.prototype.getHash = function(hash, callback) {
 
 };
 
-
-
 /**
  * Verifies that the GovObject Hash provided is valid.
  *
@@ -70,19 +68,28 @@ GovObjectController.prototype.getHash = function(hash, callback) {
  * @param res
  * @param next
  */
-GovObjectController.prototype.checkHash = function(req, res, next) {
+GovObjectController.prototype.validateHash = function(req, res, next) {
     req.hash = req.params.hash;
-    this.check(req, res, next, [req.hash]);
-
+    this.isValidHash(req, res, next, [req.hash]);
 };
 
-GovObjectController.prototype.check = function(req, res, next, hash) {
+GovObjectController.prototype.isValidHash = function(req, res, next, hash) {
     // TODO: Implement some type of validation
-
     if(hash) next();
-
 };
 
+
+GovObjectController.prototype.govObjectCheck = function(req, res) {
+  var self = this;
+  var hexdata = req.params.hexdata;
+
+  this.node.services.bitcoind.govObjectCheck(hexdata, function(err, result) {
+    if (err) {
+      return self.common.handleErrors(err, res);
+    }
+    res.jsonp(result);
+  });
+};
 
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -228,7 +228,7 @@ InsightAPI.prototype.setupRoutes = function(app) {
   //Masternodes
   var masternodes = new MasternodesController(this.node);  
   app.get('/masternodes/list', this.cacheShort(), masternodes.list.bind(masternodes));
-  
+  app.get('/masternodes/validate/:payee', this.cacheShort(), masternodes.validate.bind(masternodes));
   // Status route
   var status = new StatusController(this.node);
   app.get('/status', this.cacheShort(), status.show.bind(status));

--- a/lib/index.js
+++ b/lib/index.js
@@ -223,7 +223,8 @@ InsightAPI.prototype.setupRoutes = function(app) {
 
   var govObject = new GovObjectController(this.node);
   app.get('/gobject/list/:filter', this.cacheShort(), govObject.list.bind(govObject));
-  app.get('/gobject/get/:hash', this.cacheShort(), govObject.checkHash.bind(govObject), govObject.show.bind(govObject));
+  app.get('/gobject/get/:hash', this.cacheShort(), govObject.validateHash.bind(govObject), govObject.show.bind(govObject));
+  app.get('/gobject/check/:hexdata', this.cacheShort(), govObject.govObjectCheck.bind(govObject));
   
   //Masternodes
   var masternodes = new MasternodesController(this.node);  

--- a/lib/index.js
+++ b/lib/index.js
@@ -188,6 +188,11 @@ InsightAPI.prototype.setupRoutes = function(app) {
 
   app.get('/block-index/:height', this.cacheShort(), blocks.blockIndex.bind(blocks));
   app.param('height', blocks.blockIndex.bind(blocks));
+  
+  //Return 25 next blocks from blockHash or blockHeigth
+  app.get('/block-headers/:blockIdentifier',this.cacheLong(),blocks.blockHeaders.bind(blocks));
+  //Return nbOfBlock's blocks next from blockHash or blockHeight
+  app.get('/block-headers/:blockIdentifier/:nbOfBlock',this.cacheLong(),blocks.blockHeaders.bind(blocks));
 
   // Transaction routes
   var transactions = new TxController(this.node);

--- a/lib/masternodes.js
+++ b/lib/masternodes.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var Common = require('./common');
+var bitcore = require('bitcore-lib-dash');
+var _ = bitcore.deps._;
 
 function MasternodeController(node) {
 	this.node = node;
@@ -16,6 +18,73 @@ MasternodeController.prototype.list = function(req, res) {
 		res.jsonp(result);
 	});
 };
+
+MasternodeController.prototype.validate = function (req, res, next) {
+    var payeeAddr = req.params.payee;
+    //We first validate that the payee address is valid
+    var self = this;
+    if(!payeeAddr || payeeAddr.length!=34 ) {
+        return self.common.handleErrors({
+            message: 'Must include a valid format address',
+            code: 1
+        }, res);
+    }
+
+	try {
+		var a = new bitcore.Address(payeeAddr);
+	} catch(e) {
+		return self.common.handleErrors({
+			message: 'Invalid address: ' + e.message,
+			code: 1
+		}, res);
+	}
+
+
+	//After having valide addr, we get the MNList
+	this.getMNList(function(err, mnList){
+		if(err){
+			return self.common.handleErrors(err, res);
+		}
+
+		var filteredMnList = mnList.filter(function(elem){
+			return elem.payee === payeeAddr;
+		});
+
+		if(!filteredMnList || !filteredMnList[0]){
+			return res.jsonp({valid:false, payee:payeeAddr});
+		}
+		var mn = filteredMnList[0];
+		mn.valid = false;
+
+		if(!mn.hasOwnProperty('payee') ||
+			mn.hasOwnProperty('vin')){
+			var vin = mn.vin.split('-');
+			var txid = vin[0];
+			var voutindex = vin[1];
+
+			self.node.getDetailedTransaction(txid, function(err, transaction) {
+					if (err && err.code === -5) {
+							return self.common.handleErrors(null, res);
+					} else if(err) {
+							return self.common.handleErrors(err, res);
+					}
+					if(transaction.outputs && transaction.outputs[voutindex]){
+						var txvout = transaction.outputs[voutindex]
+						if(txvout.satoshis===100000000000 &&
+							txvout.spentTxId===undefined &&
+							txvout.spentHeight===undefined &&
+							txvout.spentIndex===undefined){
+								mn.valid = true;
+								res.jsonp(mn)
+						}else{
+								res.jsonp(mn)
+						}
+					}
+			});
+		}
+	})
+};
+
 MasternodeController.prototype.getMNList = function(callback) {
 	this.node.services.bitcoind.getMNList(function(err, result){
 		var MNList = result || [];
@@ -25,4 +94,5 @@ MasternodeController.prototype.getMNList = function(callback) {
 		callback(null,MNList);
 	});
 };
+
 module.exports = MasternodeController;

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -176,7 +176,7 @@ TxController.prototype.transformInvTransaction = function(transaction) {
     }
   }
 
-  var isRBF = _.any(_.pluck(transaction.inputs, 'sequenceNumber'), function(seq) {
+  var isRBF = _.some(_.map(transaction.inputs, 'sequenceNumber'), function(seq) {
     return seq < MAXINT - 1;
   });
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,7 +27,7 @@ UtilsController.prototype.estimateFee = function(req, res) {
     if (err) {
       return self.common.handleErrors(err, res);
     }
-    res.jsonp(_.zipObject(result));
+    res.jsonp(_.fromPairs(result));
   });
 
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1010 @@
+{
+  "name": "insight-api-dash",
+  "version": "0.6.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "accepts": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+      "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+      "requires": {
+        "mime-types": "2.1.17",
+        "negotiator": "0.6.1"
+      }
+    },
+    "ajv": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
+      "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "requires": {
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        }
+      }
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "basic-auth": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
+      "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "bitcore-lib-dash": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/bitcore-lib-dash/-/bitcore-lib-dash-0.15.2.tgz",
+      "integrity": "sha512-NKoFfFrhp5EKv8MZFjYt1lna/4dUIBtzRpzD0t5Sfpgk3uoXD7VqCCyneSy4icTWYf3tQzVU4Ba9GYeU8QzwxQ==",
+      "requires": {
+        "bn.js": "2.0.4",
+        "bs58": "2.0.0",
+        "buffer-compare": "1.0.0",
+        "elliptic": "3.0.3",
+        "inherits": "2.0.1",
+        "lodash": "4.17.1",
+        "sha512": "0.0.1",
+        "x11-hash-js": "1.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.1.tgz",
+          "integrity": "sha1-516vF6NHMMZJHZlW9NgfOgRPAb8="
+        }
+      }
+    },
+    "bitcore-message-dash": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bitcore-message-dash/-/bitcore-message-dash-1.0.9.tgz",
+      "integrity": "sha512-3RW35nqD2jB9E4sgLk1UIeIrpGtQ8EZSfOcFFKqR1gInWdqHSKHqTqpWNSQmwr+Y4qQ8i5iZJaa1jASxaAAkVg==",
+      "requires": {
+        "bitcore-lib-dash": "0.15.2"
+      }
+    },
+    "bn.js": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.4.tgz",
+      "integrity": "sha1-Igp81nf38b+pNif/QZN3b+eBlIA="
+    },
+    "body-parser": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "1.0.4",
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "on-finished": "2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "1.6.15"
+      }
+    },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "requires": {
+        "hoek": "4.2.0"
+      }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "bs58": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.0.tgz",
+      "integrity": "sha1-crcTvtIjoKxRi72g484/SBfznrU="
+    },
+    "buffer-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-compare/-/buffer-compare-1.0.0.tgz",
+      "integrity": "sha1-rKp6lm6Y7un64Usxw5pfFY+zxKI="
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.2",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "compressible": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
+      "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
+    "compression": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
+      "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
+      "requires": {
+        "accepts": "1.3.4",
+        "bytes": "3.0.0",
+        "compressible": "2.0.12",
+        "debug": "2.6.9",
+        "on-headers": "1.0.1",
+        "safe-buffer": "5.1.1",
+        "vary": "1.1.2"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "requires": {
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        }
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "depd": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "elliptic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
+      "integrity": "sha1-hlybQgv75VAGuflp+XoNLESWZZU=",
+      "requires": {
+        "bn.js": "2.0.4",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.3",
+        "inherits": "2.0.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "1.0.1",
+        "merge-descriptors": "1.0.1"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
+    },
+    "formatio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+      "dev": true,
+      "requires": {
+        "samsam": "1.1.2"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.1",
+        "minimatch": "0.3.0"
+      }
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.5.1",
+        "har-schema": "2.0.0"
+      }
+    },
+    "hash.js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "requires": {
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
+      }
+    },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.1.0"
+      }
+    },
+    "hoek": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+    },
+    "http-errors": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "requires": {
+        "depd": "1.1.1",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.4.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
+    "inherits": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+    },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.1.tgz",
+      "integrity": "sha1-516vF6NHMMZJHZlW9NgfOgRPAb8="
+    },
+    "lolex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+    },
+    "mime-types": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
+    "minimalistic-assert": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+    },
+    "minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2.7.3",
+        "sigmund": "1.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+          "dev": true
+        }
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        }
+      }
+    },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
+    },
+    "morgan": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
+      "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
+      "requires": {
+        "basic-auth": "2.0.0",
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "proxyquire": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.8.0.tgz",
+      "integrity": "sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=",
+      "dev": true,
+      "requires": {
+        "fill-keys": "1.0.2",
+        "module-not-found-error": "1.0.1",
+        "resolve": "1.1.7"
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "raw-body": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
+      }
+    },
+    "request": {
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
+      }
+    },
+    "resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "samsam": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+      "dev": true
+    },
+    "setprototypeof": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+    },
+    "sha512": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/sha512/-/sha512-0.0.1.tgz",
+      "integrity": "sha1-JuWQIu9qvHXHNE8KXvOTbK8lQtU="
+    },
+    "should": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/should/-/should-8.4.0.tgz",
+      "integrity": "sha1-XmCInT5kS73Tl6MM00+tKPz5C8A=",
+      "dev": true,
+      "requires": {
+        "should-equal": "0.8.0",
+        "should-format": "0.3.2",
+        "should-type": "0.2.0"
+      }
+    },
+    "should-equal": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.8.0.tgz",
+      "integrity": "sha1-o/BXMv9FusG3ukEvhAiFaBlkEpk=",
+      "dev": true,
+      "requires": {
+        "should-type": "0.2.0"
+      }
+    },
+    "should-format": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-0.3.2.tgz",
+      "integrity": "sha1-pZgx4Bot3uFJkRvHFIvlyAMZ4f8=",
+      "dev": true,
+      "requires": {
+        "should-type": "0.2.0"
+      }
+    },
+    "should-type": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.2.0.tgz",
+      "integrity": "sha1-ZwfvlVKdmJ3MCY/gdTqx+RNrt/Y=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "sinon": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "dev": true,
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": "0.10.3"
+      }
+    },
+    "sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "requires": {
+        "hoek": "4.2.0"
+      }
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "statuses": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "supports-color": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+      "dev": true
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    },
+    "type-is": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.17"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      }
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    },
+    "x11-hash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/x11-hash-js/-/x11-hash-js-1.0.0.tgz",
+      "integrity": "sha1-hYn83+ezXbM/KDk5U7He+AzzTd4="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insight-api-dash",
   "description": "A Dash blockchain REST and web socket API service for Bitcore Node.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "repository": "git://github.com/dashevo/insight-api-dash.git",
   "contributors": [
     {
@@ -61,11 +61,11 @@
   "bitcoreNode": "lib",
   "dependencies": {
     "async": "*",
-    "bitcore-lib-dash": "^0.14.1",
-    "bitcore-message-dash": "^1.0.6",
+    "bitcore-lib-dash": "^0.15.2",
+    "bitcore-message-dash": "^1.0.9",
     "body-parser": "^1.13.3",
     "compression": "^1.6.1",
-    "lodash": "^2.4.1",
+    "lodash": "=4.17.1",
     "lru-cache": "^4.0.1",
     "morgan": "^1.7.0",
     "request": "^2.64.0"

--- a/test/blocks.js
+++ b/test/blocks.js
@@ -56,6 +56,24 @@ var blockIndexes = {
     height: 599999,
     difficulty: 75786.58855499285
   },
+  '0000047d24635e347be3aaaeb66c26be94901a2f962feccd4f95090191f208c1':{
+    hash: '0000047d24635e347be3aaaeb66c26be94901a2f962feccd4f95090191f208c1',
+    chainWork: '0000000000000000000000000000000000000000000000000000000000200011',
+    prevHash: '00000bafbc94add76cb75e2ec92894837288a481e5c005f6563d91623bf8bc2c',
+    nextHash: '00000c6264fab4ba2d23990396f42a76aa4822f03cbc7634b79f4dfea36fccc2',
+    confirmations: 40493,
+    height: 1,
+    difficulty: 0.0002441371325370145
+  },
+  1:{
+    hash: '0000047d24635e347be3aaaeb66c26be94901a2f962feccd4f95090191f208c1',
+    chainWork: '0000000000000000000000000000000000000000000000000000000000200011',
+    prevHash: '00000bafbc94add76cb75e2ec92894837288a481e5c005f6563d91623bf8bc2c',
+    nextHash: '00000c6264fab4ba2d23990396f42a76aa4822f03cbc7634b79f4dfea36fccc2',
+    confirmations: 40493,
+    height: 1,
+    difficulty: 0.0002441371325370145
+  },
   533974: {
     hash: '0000000000000afa0c3c0afd450c793a1e300ec84cbe9555166e06132f19a8f7',
     chainWork: '0000000000000000000000000000000000000000000000054626b1839ade284a',
@@ -362,4 +380,94 @@ describe('Blocks', function() {
 
     blocks.getBlockReward('000000000000c53bf17a98b9ee042d6d4c3faf37d7a9f5c1335cce6df896f2f4', cb); // should return difficulty of block 100000
   });
+});
+
+describe('#getHeaders', function(){
+	describe('/block-headers/:height route', function() {
+		var node = {
+			log: sinon.stub(),
+			services: {
+				bitcoind: {
+					getBlockHeaders: function(blockIdentifier, callback, nbBlock) {
+					  var result = [];
+					  for(var i = 0; i<nbBlock; i++){
+					    result.push(blockIndexes[blockIdentifier])
+            }
+						callback(null, result);
+					}
+				}
+			}
+		};
+		it('should give an array of 25 block headers', function() {
+			var blocks = new BlockController({node: node});
+
+			var insight = {
+        hash: '0000047d24635e347be3aaaeb66c26be94901a2f962feccd4f95090191f208c1',
+        chainWork: '0000000000000000000000000000000000000000000000000000000000200011',
+        prevHash: '00000bafbc94add76cb75e2ec92894837288a481e5c005f6563d91623bf8bc2c',
+        nextHash: '00000c6264fab4ba2d23990396f42a76aa4822f03cbc7634b79f4dfea36fccc2',
+        confirmations: 40493,
+        height: 1,
+        difficulty: 0.0002441371325370145
+    };
+			var req = {
+				params: {
+          blockIdentifier: "0000047d24635e347be3aaaeb66c26be94901a2f962feccd4f95090191f208c1"
+				}
+			};
+			var res = {
+				jsonp: function(data) {
+				  data.should.have.property('headers');
+          data.headers.should.have.length(25);
+					should(data.headers[0]).eql(insight);
+				}
+			};
+
+      blocks.blockHeaders(req, res)
+		});
+	});
+	describe('/block-headers/:height/:nbOfBlock route', function() {
+		var node = {
+			log: sinon.stub(),
+			services: {
+				bitcoind: {
+          getBlockHeaders: function(blockIdentifier, callback, nbBlock) {
+            var result = [];
+            for(var i = 0; i<nbBlock; i++){
+              result.push(blockIndexes[blockIdentifier])
+            }
+            callback(null, result);
+          }
+				}
+			}
+		};
+		it('should give an array of 50 block headers', function() {
+			var blocks = new BlockController({node: node});
+			var insight = {
+        hash: '0000047d24635e347be3aaaeb66c26be94901a2f962feccd4f95090191f208c1',
+        chainWork: '0000000000000000000000000000000000000000000000000000000000200011',
+        prevHash: '00000bafbc94add76cb75e2ec92894837288a481e5c005f6563d91623bf8bc2c',
+        nextHash: '00000c6264fab4ba2d23990396f42a76aa4822f03cbc7634b79f4dfea36fccc2',
+        confirmations: 40493,
+        height: 1,
+        difficulty: 0.0002441371325370145
+			};
+			var height = 533974;
+			var req = {
+				params: {
+					blockIdentifier: "0000047d24635e347be3aaaeb66c26be94901a2f962feccd4f95090191f208c1",
+					nbOfBlock:50
+				}
+			};
+			var res = {
+				jsonp: function(data) {
+          data.should.have.property('headers');
+          data.headers.should.have.length(50);
+          should(data.headers[0]).eql(insight);
+				}
+			};
+
+			blocks.blockHeaders(req, res);
+		});
+	});
 });


### PR DESCRIPTION
- Feat : Provides getHeaders feature through a new /block-headers routes
- Feat : Validate a masternode payee adress as still being valid (by checking if collateral is not spent)
- Feat : Additional gobject/get/:hash and gobject/check/hexdata routes for proposal validation

This version has a dependency on bitcore-node-dash : 
https://github.com/dashevo/bitcore-node-dash/pull/19